### PR TITLE
test(AppNavigationTest/clickOnNavigationDrawerItem_ChangeTheme): label as flaky

### DIFF
--- a/app/src/androidTest/java/io/github/marktony/espresso/packages/AppNavigationTest.java
+++ b/app/src/androidTest/java/io/github/marktony/espresso/packages/AppNavigationTest.java
@@ -120,7 +120,7 @@ public class AppNavigationTest {
                 .check(matches(isDisplayed()));
     }
 
-    @FlakyTest
+    @FlakyTest(detail = "After performing changing the theme, the background color might not be changed before the check.")
     @Test
     public void clickOnNavigationDrawerItem_ChangeTheme() {
         // Open drawer to click on navigation.

--- a/app/src/androidTest/java/io/github/marktony/espresso/packages/AppNavigationTest.java
+++ b/app/src/androidTest/java/io/github/marktony/espresso/packages/AppNavigationTest.java
@@ -2,6 +2,7 @@ package io.github.marktony.espresso.packages;
 
 import android.graphics.drawable.ColorDrawable;
 import android.support.test.filters.LargeTest;
+import android.support.test.filters.FlakyTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.v7.widget.Toolbar;
@@ -119,6 +120,7 @@ public class AppNavigationTest {
                 .check(matches(isDisplayed()));
     }
 
+    @FlakyTest
     @Test
     public void clickOnNavigationDrawerItem_ChangeTheme() {
         // Open drawer to click on navigation.


### PR DESCRIPTION
After performing changing the theme, the background color might not be changed before the check.
Therefore, this test case can sometimes fail. Labeling it as flaky to document.